### PR TITLE
Fix autoplay and settings button contrast

### DIFF
--- a/assets/player.js
+++ b/assets/player.js
@@ -24,6 +24,7 @@ export function createPlayerHook(iceServers = []) {
     async connect(view) {
       view.el.srcObject = undefined;
       view.pc = new RTCPeerConnection({ iceServers: iceServers });
+      view.el.play();
 
       view.pc.onicecandidate = (ev) => {
         view.pushEventTo(view.el, "ice", JSON.stringify(ev.candidate));
@@ -41,6 +42,6 @@ export function createPlayerHook(iceServers = []) {
       await view.pc.setLocalDescription(offer);
 
       view.pushEventTo(view.el, "offer", offer);
-    }
+    },
   };
 }

--- a/lib/live_ex_webrtc/player.ex
+++ b/lib/live_ex_webrtc/player.ex
@@ -231,7 +231,6 @@ defmodule LiveExWebRTC.Player do
           phx-hook="Player"
           class={["w-full h-full", @video_class]}
           controls
-          autoplay
           muted
         >
         </video>
@@ -337,7 +336,7 @@ defmodule LiveExWebRTC.Player do
   @impl true
   def handle_info(
         {:ex_webrtc, pc, {:connection_state_change, :failed}},
-        %{assigns: %{player: %{pc: pc}}} 
+        %{assigns: %{player: %{pc: pc}}}
       ) do
     exit(:pc_failed)
   end

--- a/lib/live_ex_webrtc/player.ex
+++ b/lib/live_ex_webrtc/player.ex
@@ -268,7 +268,7 @@ defmodule LiveExWebRTC.Player do
 
         <button
           phx-click="toggle-settings"
-          class="absolute top-6 left-6 duration-300 ease-in-out group-hover:visible invisible transition-opacity opacity-0 group-hover:opacity-100 rounded-lg hover:bg-stone-800 p-2"
+          class="absolute top-6 left-6 duration-300 ease-in-out group-hover:visible invisible transition-opacity opacity-0 group-hover:opacity-100 rounded-lg bg-stone-700 hover:bg-stone-800 p-2"
         >
           <span class="hero-cog-8-tooth text-white w-6 h-6 block" />
         </button>


### PR DESCRIPTION
Changes:
- Adding background to settings button in player in order to increase contrast
- Removing autoplay in player and starting it manually after we connect to RTC player. It is required to prevent the following error during liveview navigation:
```
Uncaught (in promise) AbortError: The play() request was interrupted by a new load request. https://goo.gl/LdLk22
```