### PR TITLE
Allow H264 packetization_mode=0

### DIFF
--- a/lib/live_ex_webrtc/player.ex
+++ b/lib/live_ex_webrtc/player.ex
@@ -35,7 +35,7 @@ defmodule LiveExWebRTC.Player do
 
   ## Simulcast
 
-  Simulcast requires video codecs to be H264 (packetization mode 1) and/or VP8.
+  Simulcast requires video codecs to be H264 and/or VP8.
   See `LiveExWebRTC.Publisher` module doc for more.
 
   ## Examples

--- a/lib/live_ex_webrtc/publisher.ex
+++ b/lib/live_ex_webrtc/publisher.ex
@@ -52,7 +52,7 @@ defmodule LiveExWebRTC.Publisher do
 
   ## Simulcast
 
-  Simulcast requires video codecs to be H264 (packetization mode 1) and/or VP8. E.g.
+  Simulcast requires video codecs to be H264 and/or VP8. E.g.
 
   ```elixir
   video_codecs = [
@@ -803,8 +803,7 @@ defmodule LiveExWebRTC.Publisher do
         true
 
       %RTPCodecParameters{mime_type: "video/H264", sdp_fmtp_line: fmtp} when fmtp != nil ->
-        fmtp.level_asymmetry_allowed == true and fmtp.packetization_mode == 1 and
-          fmtp.profile_level_id == 0x42E01F
+        fmtp.level_asymmetry_allowed == true and fmtp.profile_level_id == 0x42E01F
 
       _ ->
         false


### PR DESCRIPTION
Once https://github.com/elixir-webrtc/ex_webrtc/pull/220 is merged and released, simulcast with H264 packetization_mode=0 will work just fine.